### PR TITLE
add serverless-sharp-image service to service/projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@
 - [Authorizer](https://github.com/eahefnawy/serverless-authorizer) - Service that uses API Gateway custom authorizers.
 - [Thumbnails](https://github.com/eahefnawy/serverless-thumbnails) - Service that takes an image url and returns a 100x100 thumbnail.
 - [Boilerplate](https://github.com/eahefnawy/serverless-boilerplate) - Opinionated boilerplate.
+- [Serverless Sharp Image](https://github.com/adieuadieu/serverless-sharp-image) - function triggered by S3 events to resize images with the awesome Sharp library
 
 ## Plugins
 


### PR DESCRIPTION
Add the serverless-sharp-image service to the services/projects section.

Disclosure: I'm the author of the project
