### PR TITLE
added lambda-restify in readme > projects/services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@
 - [Slack invite](https://github.com/serverless-london/serverless-slack-invite) - Serverless Slack invite service.
 - [Slack sign-up](https://github.com/dzimine/slack-signup-serverless) - Serverless sign-up to Slack (and other services).
 - [Image resizer](https://github.com/nicholasgubbins/Serverless-Image-Resizer) - Image resizer like imgix on API Gateway & Lambda.
+- [lambda-restify](https://github.com/kksharma1618/lambda-restify) - A restify/expressjs like interface for aws lamda with api gateway event.
 
 ## Related projects
 


### PR DESCRIPTION
Hey,

I added [lambda-restify](https://github.com/kksharma1618/lambda-restify) in projects/services section. That section doesn't seem to have any alphabetical order so I just added it in the end. 

Lambda restify is an npm module that exposes restify/expressjs like interface when using aws lambda with api gateway. It handles request/response/routing/versioned apis/middlewares. 