### PR TITLE
Proposal to add serverless-go-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1852,6 +1852,7 @@
 - [Node shim](https://github.com/jzimmek/serverless-plugin-node-shim) - Run your functions with Node.js version (8 LTS, 9+) on AWS Lambda.
 - [Static](https://github.com/iliasbhal/serverless-static) - Serve / deploy static files that works with the `serverless-offline` plugin.
 - [Remove forced login](https://github.com/pmuens/serverless-remove-forced-login) - Removes the forced login when using `serverless run` and `serverless emit`.
+- [Go build](https://github.com/sean9keenan/serverless-go-build) - Build go source files (or public functions) using yml definition file.
 
 ## Literature / Education
 


### PR DESCRIPTION
Full disclosure: This is a plugin I just recently made.

Also not sure where it should go in the list of plugins, doesn't see to be any particular order even though I see the guidelines say to put in alphabetical order

I do believe it's a large improvement for building go projects with the serverless framework! Feedback on the [Readme](https://github.com/sean9keenan/serverless-go-build/blob/master/README.md) in the project is also welcome. Thanks!