### PR TITLE
Add lgw

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 
 ## Projects
 
+- [Lambda Gateway](https://github.com/ebridges/lgw) - `lgw` is a tool to simply, easily configure an AWS Gateway and Domain Name in front of a Lambda function.
 - [Official joke API](https://github.com/15Dkatz/official_joke_api) - Vue Jokester application backend.
 - [Event Gateway Getting Started](https://github.com/serverless/event-gateway-getting-started) - Walkthrough application for using the Event Gateway.
 - [Utils](https://github.com/serverless/utils) - General Serverless utilities.


### PR DESCRIPTION
`lgw` (lambda gateway) is a tool to simply, easily configure an AWS Gateway and Domain Name in front of a Lambda function.